### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.30](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.30) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.51](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.51) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.99](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.99) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,5 +4,5 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.42](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.42) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.30](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.30) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.99](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.99) | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,5 +4,5 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.42](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.42) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.99](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.99) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.36
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36
+  version: 0.0.99
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.99

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-agenda
   url: https://github.com/salaboy/fmtok8s-agenda
-  version: 0.0.13
-  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13
+  version: 0.0.42
+  versionURL: https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.42
 - host: github.com
   owner: salaboy
   repo: fmtok8s-api-gateway

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-email
   url: https://github.com/salaboy/fmtok8s-email
-  version: 0.0.9
-  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9
+  version: 0.0.30
+  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.30
 - host: github.com
   owner: salaboy
   repo: fmtok8s-c4p

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.27
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27
+  version: 0.0.51
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.51
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda

--- a/springone-app/requirements.yaml
+++ b/springone-app/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: fmtok8s-agenda
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.13
+  version: 0.0.42
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.27

--- a/springone-app/requirements.yaml
+++ b/springone-app/requirements.yaml
@@ -10,4 +10,4 @@ dependencies:
   version: 0.0.99
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.9
+  version: 0.0.30

--- a/springone-app/requirements.yaml
+++ b/springone-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.42
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.27
+  version: 0.0.51
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.99

--- a/springone-app/requirements.yaml
+++ b/springone-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.27
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.36
+  version: 0.0.99
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.9


### PR DESCRIPTION
Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) from [0.0.27](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.27) to [0.0.51](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.51)

Command run was `jx step create pr chart --name fmtok8s-c4p --version 0.0.51 --repo https://github.com/salaboy/fmtok8s-springone-app.git`
<hr />

Update [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) from [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) to [0.0.30](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.30)

Command run was `jx step create pr chart --name fmtok8s-email --version 0.0.30 --repo https://github.com/salaboy/fmtok8s-springone-app.git`
<hr />

Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.36](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.36) to [0.0.99](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.99)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.99 --repo https://github.com/salaboy/fmtok8s-springone-app.git`
<hr />

Update [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) from [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) to [0.0.42](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.42)

Command run was `jx step create pr chart --name fmtok8s-agenda --version 0.0.42 --repo https://github.com/salaboy/fmtok8s-springone-app.git`