### PR TITLE
chore(deps): bump https://github.com/salaboy/fmtok8s-api-gateway from 0.0.99 to 0.0.100

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.9](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.9) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.30](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.30) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.51](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.51) | 
-[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.13](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.13) | 
-[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.99](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.99) | 
+[salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.42](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.42) | 
+[salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.100](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.100) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -21,5 +21,5 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-api-gateway
   url: https://github.com/salaboy/fmtok8s-api-gateway
-  version: 0.0.99
-  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.99
+  version: 0.0.100
+  versionURL: https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.100

--- a/springone-app/requirements.yaml
+++ b/springone-app/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   version: 0.0.51
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.99
+  version: 0.0.100
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.30


### PR DESCRIPTION
Update [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) from [0.0.99](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.99) to [0.0.100](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.100)

Command run was `jx step create pr chart --name fmtok8s-api-gateway --version 0.0.100 --repo https://github.com/salaboy/fmtok8s-springone-app.git`