### PR TITLE
chore(deps): bump https://github.com/salaboy/fmtok8s-c4p from 0.0.51 to 0.0.52

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,6 +3,6 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.30](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.30) | 
-[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.51](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.51) | 
+[salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.52](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.52) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.42](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.42) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.101](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.101) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -9,8 +9,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-c4p
   url: https://github.com/salaboy/fmtok8s-c4p
-  version: 0.0.51
-  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.51
+  version: 0.0.52
+  versionURL: https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.52
 - host: github.com
   owner: salaboy
   repo: fmtok8s-agenda

--- a/springone-app/requirements.yaml
+++ b/springone-app/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   version: 0.0.42
 - name: fmtok8s-c4p
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.51
+  version: 0.0.52
 - name: fmtok8s-api-gateway
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.101


### PR DESCRIPTION
Update [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) from [0.0.51](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.51) to [0.0.52](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.52)

Command run was `jx step create pr chart --name fmtok8s-c4p --version 0.0.52 --repo https://github.com/salaboy/fmtok8s-springone-app.git`