### PR TITLE
chore(deps): bump https://github.com/salaboy/fmtok8s-email from 0.0.35 to 0.0.36

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -2,7 +2,7 @@
 
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
-[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.35](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.35) | 
+[salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) |  | [0.0.36](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.36) | 
 [salaboy/fmtok8s-c4p](https://github.com/salaboy/fmtok8s-c4p) |  | [0.0.52](https://github.com/salaboy/fmtok8s-c4p/releases/tag/v0.0.52) | 
 [salaboy/fmtok8s-agenda](https://github.com/salaboy/fmtok8s-agenda) |  | [0.0.42](https://github.com/salaboy/fmtok8s-agenda/releases/tag/v0.0.42) | 
 [salaboy/fmtok8s-api-gateway](https://github.com/salaboy/fmtok8s-api-gateway) |  | [0.0.101](https://github.com/salaboy/fmtok8s-api-gateway/releases/tag/v0.0.101) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -3,8 +3,8 @@ dependencies:
   owner: salaboy
   repo: fmtok8s-email
   url: https://github.com/salaboy/fmtok8s-email
-  version: 0.0.35
-  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.35
+  version: 0.0.36
+  versionURL: https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.36
 - host: github.com
   owner: salaboy
   repo: fmtok8s-c4p

--- a/springone-app/requirements.yaml
+++ b/springone-app/requirements.yaml
@@ -10,4 +10,4 @@ dependencies:
   version: 0.0.101
 - name: fmtok8s-email
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.35
+  version: 0.0.36


### PR DESCRIPTION
Update [salaboy/fmtok8s-email](https://github.com/salaboy/fmtok8s-email) from [0.0.35](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.35) to [0.0.36](https://github.com/salaboy/fmtok8s-email/releases/tag/v0.0.36)

Command run was `jx step create pr chart --name fmtok8s-email --version 0.0.36 --repo https://github.com/salaboy/fmtok8s-springone-app.git`